### PR TITLE
Fixing a small issue with old git version

### DIFF
--- a/content/docs/git/git_and_github.md
+++ b/content/docs/git/git_and_github.md
@@ -97,7 +97,11 @@ cd <github-username>
 Initialise an empty git repository with the branch name, `main`:
 
 ```shell
-git init -b main
+git init
+```
+
+```shell
+git checkout -b main
 ```
 
 Now you have an empty local repository 🎉


### PR DESCRIPTION
Hi guys, 
This PR is a small fix for git older than 2.28.0 version.
In order to run git init and create a new branch in the same command, we need to have at least git running on 2.28.0 version. We have some problems with students running the old version, then I splitted those two commands.